### PR TITLE
add more versions of Java

### DIFF
--- a/src/jetbrains/buildServer/tools/java/JavaVersion.java
+++ b/src/jetbrains/buildServer/tools/java/JavaVersion.java
@@ -27,6 +27,9 @@ import org.jetbrains.annotations.Nullable;
 public enum JavaVersion {
   ///see http://en.wikipedia.org/wiki/Java_class_file
 
+  Java_14(58, "Java 14", "14"),
+  Java_13(57, "Java 13", "13"),
+  Java_12(56, "Java 12", "12"),
   Java_11(55, "Java 11", "11"),
   Java_10(54, "Java 10", "10"),
   Java_9(53, "Java 9", "9"),


### PR DESCRIPTION
This commit adds more versions of Java so that class version checker did not report anything > 55 as unknown.