### PR TITLE
skip META-INF/**/module-info.class by default

### DIFF
--- a/src/jetbrains/buildServer/tools/checkers/ClassFileChecker.java
+++ b/src/jetbrains/buildServer/tools/checkers/ClassFileChecker.java
@@ -39,6 +39,10 @@ public class ClassFileChecker implements CheckAction {
   }
 
   public void process(@NotNull ScanFile file, @NotNull ErrorReporting reporting) throws IOException {
+    // there is no reason to scan module-info.class because it will be loaded only by corresponding JVM version
+    if (file.getName().startsWith("META-INF/") && file.getName().endsWith("module-info.class")) {
+      return;
+    }
     checkVersion(file, reporting);
   }
 


### PR DESCRIPTION
skip META-INF/**/module-info.class by default because their presence does not mean other classes from the jar cannot be loaded by an older JVM